### PR TITLE
Fixed step definition issue

### DIFF
--- a/features/step_definitions/users_assignments_tests_steps.rb
+++ b/features/step_definitions/users_assignments_tests_steps.rb
@@ -3,6 +3,7 @@ require 'rspec/mocks'
 World(RSpec::Mocks::ExampleMethods)
 
 Before do
+  OmniAuth.config.test_mode = true
   RSpec::Mocks.setup
 end
 


### PR DESCRIPTION
This PR fixes an issue with the `Login` step definitions caused by a bad merge conflict resolution.