### PR TITLE
Add `TestGrouping` Model

### DIFF
--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -26,8 +26,9 @@ class TestsController < ApplicationController
 
   # POST /tests or /tests.json
   def create
-    @assignment = Assignment.find(params[:assignment_id])  # Find the relevant assignment
-    @test = @assignment.tests.new(test_params)  # Associate test with the assignment
+    @test = Test.new(test_params)
+    @assignment = Assignment.find(params[:assignment_id])
+    @test.assignment = @assignment
 
     respond_to do |format|
       if @test.save
@@ -126,10 +127,10 @@ class TestsController < ApplicationController
   final_error_message.join(", ")
 end
 
+private
 
-
-    # Only allow a list of trusted parameters through.
-    def test_params
-      params.require(:test).permit(:name, :points, :test_type, :target, :include, :number, :show_output, :skip, :timeout, :visibility, :assignment_id, :actual_test)
-    end
+  # Only allow a list of trusted parameters through.
+  def test_params
+    params.require(:test).permit(:name, :points, :test_type, :target, :include, :number, :show_output, :skip, :timeout, :visibility, :assignment_id, :actual_test, :test_grouping_id)
+  end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -6,6 +6,8 @@ class Assignment < ActiveRecord::Base
   validates :repository_name, uniqueness: { message: "must be unique. This repository name is already taken." }
   validates :assignment_name, :repository_name, presence: true
 
+  after_create :ensure_default_test_grouping
+
   def repository_identifier
     File.join(ENV["GITHUB_COURSE_ORGANIZATION"], self.repository_name)
   end
@@ -91,6 +93,10 @@ class Assignment < ActiveRecord::Base
   end
 
   private
+
+  def ensure_default_test_grouping
+    test_groupings.find_or_create_by!(name: "Miscellaneous Tests")
+  end
 
   # Commit local changes to the repository
   def commit_local_changes(local_repo_path, user)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,6 +1,8 @@
 class Assignment < ActiveRecord::Base
   has_and_belongs_to_many :users
-  has_many :tests
+  has_many :test_groupings, dependent: :destroy
+  has_many :tests, through: :test_groupings, dependent: :destroy
+  has_many :tests, dependent: :destroy # TODO: remove this association once TestGrouping CRUD is implemented
   validates :repository_name, uniqueness: { message: "must be unique. This repository name is already taken." }
   validates :assignment_name, :repository_name, presence: true
 

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -1,5 +1,6 @@
 class Test < ApplicationRecord
   belongs_to :assignment
+  belongs_to :test_grouping
   validates :actual_test, presence: true
 
 

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -18,7 +18,15 @@ class Test < ApplicationRecord
   attribute :timeout, :float
   attribute :visibility, :string, default: "visible"
 
+  before_validation :set_default_test_grouping, on: :create
+
   def regenerate_tests_file
     assignment.generate_tests_file
+  end
+
+  private
+
+  def set_default_test_grouping
+    self.test_grouping ||= TestGrouping.find_by(name: "Miscellaneous Tests")
   end
 end

--- a/app/models/test_grouping.rb
+++ b/app/models/test_grouping.rb
@@ -1,0 +1,2 @@
+class TestGrouping < ApplicationRecord
+end

--- a/app/models/test_grouping.rb
+++ b/app/models/test_grouping.rb
@@ -1,2 +1,4 @@
 class TestGrouping < ApplicationRecord
+  belongs_to :assignment
+  has_many :tests
 end

--- a/app/models/test_grouping.rb
+++ b/app/models/test_grouping.rb
@@ -1,4 +1,19 @@
 class TestGrouping < ApplicationRecord
   belongs_to :assignment
   has_many :tests
+
+  after_destroy :reassign_tests_to_default_grouping
+
+  private
+
+  def reassign_tests_to_default_grouping
+    default_grouping = assignment.test_groupings.find_by(name: "Miscellaneous Tests")
+    # if deleted grouping is the default grouping, delete all tests
+    if name == "Miscellaneous Tests"
+      tests.destroy_all
+      return
+    end
+
+    tests.update_all(test_grouping_id: default_grouping.id)
+  end
 end

--- a/db/migrate/20241013174038_create_test_groupings.rb
+++ b/db/migrate/20241013174038_create_test_groupings.rb
@@ -1,0 +1,10 @@
+class CreateTestGroupings < ActiveRecord::Migration[7.2]
+  def change
+    create_table :test_groupings do |t|
+      t.string :name
+      t.integer :number
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241013190211_add_assignment_to_test_groupings.rb
+++ b/db/migrate/20241013190211_add_assignment_to_test_groupings.rb
@@ -1,0 +1,5 @@
+class AddAssignmentToTestGroupings < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :test_groupings, :assignment, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20241013190343_add_test_grouping_to_tests.rb
+++ b/db/migrate/20241013190343_add_test_grouping_to_tests.rb
@@ -1,0 +1,5 @@
+class AddTestGroupingToTests < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :tests, :test_grouping, foreign_key: true
+  end
+end

--- a/db/migrate/20241013190727_backfill_test_grouping_id_in_tests.rb
+++ b/db/migrate/20241013190727_backfill_test_grouping_id_in_tests.rb
@@ -1,0 +1,8 @@
+class BackfillTestGroupingIdInTests < ActiveRecord::Migration[7.2]
+  def up
+    Assignment.find_each do |assignment|
+      default_grouping = assignment.test_groupings.create!(name: "Miscellaneous Tests")
+      assignment.tests.update_all(test_grouping_id: default_grouping.id)
+    end
+  end
+end

--- a/db/migrate/20241013193346_add_not_null_constraint_to_test_grouping_id_in_tests.rb
+++ b/db/migrate/20241013193346_add_not_null_constraint_to_test_grouping_id_in_tests.rb
@@ -1,0 +1,5 @@
+class AddNotNullConstraintToTestGroupingIdInTests < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :tests, :test_grouping_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_07_001115) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_13_193346) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -56,6 +56,15 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_07_001115) do
     t.index ["user_id"], name: "index_assignments_users_on_user_id"
   end
 
+  create_table "test_groupings", force: :cascade do |t|
+    t.string "name"
+    t.integer "number"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "assignment_id", null: false
+    t.index ["assignment_id"], name: "index_test_groupings_on_assignment_id"
+  end
+
   create_table "tests", force: :cascade do |t|
     t.string "name"
     t.float "points"
@@ -71,7 +80,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_07_001115) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "actual_test"
+    t.integer "test_grouping_id", null: false
     t.index ["assignment_id"], name: "index_tests_on_assignment_id"
+    t.index ["test_grouping_id"], name: "index_tests_on_test_grouping_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -88,5 +99,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_07_001115) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "assignments_users", "assignments"
   add_foreign_key "assignments_users", "users"
+  add_foreign_key "test_groupings", "assignments"
   add_foreign_key "tests", "assignments"
+  add_foreign_key "tests", "test_groupings"
 end


### PR DESCRIPTION
<!--- Describe your changes in detail -->
This PR addresses issue #57:
- Adds `TestGrouping` model
- Updates associations in `Assignment`, `Test`, and `TestGrouping` to reflect new structure
- Implements a default test grouping in each assignment (since `TestGrouping` CRUD is a separate feature, this was done to ensure compatibility with our old tests. Those will be updated in the `TestGrouping` CRUD feature.)

## How has this been tested?
All existing tests pass, and I am still able to create tests through the UI.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Zero `rubocop` violations
- [ ] My code receives an "A" when `rubycritic` is run
- [x] >90% test coverage of my changes
- [x] All new and existing tests passed