### PR TITLE
Add task to `Rakefile` to delete GitHub repos

### DIFF
--- a/lib/tasks/github.rake
+++ b/lib/tasks/github.rake
@@ -1,0 +1,49 @@
+require "octokit"
+require "optparse"
+
+namespace :github do
+  desc "Delete all assignment repositories in the GitHub organization"
+  task :clean, [ :access_token, :exempt_repos ] do |t, args|
+    options = {}
+    opts = OptionParser.new do |opts|
+      opts.banner = "Usage: rake github:clean -- [options]"
+      opts.on("-a", "--access-token ACCESS_TOKEN", "GitHub personal access token") { |access_token|
+        options[:access_token] = access_token
+      }
+      opts.on("-e", "--exempt-repos EXEMPT_REPOS", "List of comma-separated repositories to exempt") { |exempt_repos|
+        options[:exempt_repos] = exempt_repos.split(",")
+      }
+    end
+
+    args = opts.order!(ARGV) { }
+    opts.parse!(args.to_a)
+
+    if options[:access_token].nil?
+        puts "Error: Access token is required. Use -a or --access-token to provide it."
+        exit 1
+    end
+    # print in red
+    puts "\e[31mWARNING: This task will delete all assignment repositories in the organization.\e[0m"
+    puts "\e[31mAre you sure you want to delete all assignment repositories in the organization?\e[0m (y/n): "
+    confirmation = STDIN.gets.chomp
+    if confirmation != "y"
+        puts "Aborted."
+        exit
+    end
+
+    access_token = options[:access_token]
+    exempt_repos = options[:exempt_repos] || []
+    exempt_repos += [ "autograder-core" ]
+
+    client = Octokit::Client.new(access_token: access_token)
+    repos = client.organization_repositories("AutograderFrontend").reject { |repo| exempt_repos.include?(repo.name) }
+
+    repos.each do |repo|
+      client.delete_repository(repo.full_name)
+      puts "Deleted repository: #{repo.full_name}"
+    end
+
+    puts "All repositories have been deleted."
+    exit
+  end
+end


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds a task to the `Rakefile` to delete all GitHub assignment repositories in the organization.  It excludes the `autograder-core` repo, but you can also specify others to exclude.

Usage: `rake github:clean -- -a <github-pat> [-e <excluded-repos>]`

The extra `--` is necessary, as it tells rake that the following arguments belong to the task, rather than the `rake` command itself.

You need to generate a GitHub personal access token to use this.  You should limit its scope to only have access to the `AutograderFrontend` organization.  The task should only delete repos within the organization but if there is a bug, other repositories that you own could be removed if you do not limit the PAT scope.

## How has this been tested?
This was run with different sets of arguments to test functionality.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Zero `rubocop` violations
- [ ] My code receives an "A" when `rubycritic` is run
- [x] >90% test coverage of my changes
- [x] All new and existing tests passed