### PR TITLE
Re-clone repo if it does not exist

### DIFF
--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -111,7 +111,7 @@ class TestsController < ApplicationController
 
   def set_test_grouping_id
     position = params[:test][:test_grouping_position]
-    test_grouping = TestGrouping.find_by(position: position)
+    test_grouping = TestGrouping.find_by(assignment_id: @assignment.id, position: position)
     @test.test_grouping_id = test_grouping.id if test_grouping
   end
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -50,6 +50,10 @@ class Assignment < ActiveRecord::Base
       # Set the remote URL for the repository
       # system("git -C #{local_repo_path} remote set-url origin #{remote_repo_url}")
 
+      # re-clone the repo if it doesn't exist
+
+      clone_repo_to_local(auth_token)
+
       set_remote_origin(local_repo_path, authenticated_url(auth_token))
 
 
@@ -102,7 +106,7 @@ class Assignment < ActiveRecord::Base
   private
 
   def authenticated_url(github_token)
-    "https://#{github_token}@#{repository_url[8..]}"
+    "https://#{github_token}@#{self.repository_url[8..]}"
   end
 
   def ensure_default_test_grouping
@@ -178,14 +182,21 @@ class Assignment < ActiveRecord::Base
       puts "Failed to clone repo from assignment template: #{e.response_body[:message]}"
       return
     end
+    # wait for remote repo to be initialized
+    sleep(3)
     self.repository_url = new_repo[:html_url]
+    puts "Repo created successfully at #{self.repository_url}"
+    self.save
   end
 
   def clone_repo_to_local(github_token)
-      # wait for remote repo to be initialized
-      sleep(3)
       begin
-        Git.clone(authenticated_url(github_token), self.local_repository_path)
+        if Dir.exist?(self.local_repository_path) && !Dir.exist?("#{self.local_repository_path}/.git")
+          FileUtils.rm_rf(self.local_repository_path)
+        end
+        if !Dir.exist?(self.local_repository_path)
+          Git.clone(authenticated_url(github_token), self.local_repository_path)
+        end
       rescue Git::Error => e
         puts "An error occurred: #{e.message}"
         nil

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -263,11 +263,11 @@ RSpec.describe Assignment, type: :model do
       assignment.push_changes_to_github(user, auth_token)
     end
 
-    it 'logs an error if the local repository does not exist' do
+    it 're-clones if repository does not exist' do
       # Simulate the repo not existing
       allow(Dir).to receive(:exist?).with(local_repo_path).and_return(false)
 
-      expect(Rails.logger).to receive(:error).with("Local repository not found for #{assignment.repository_name}")
+      expect(assignment).to receive(:clone_repo_to_local).with(auth_token)
 
       # Call the method
       assignment.push_changes_to_github(user, auth_token)


### PR DESCRIPTION
<!--- Provide a concise title -->

## Description
<!--- Describe your changes in detail -->
This PR fixes tests not being created in production, as well as tests not dropping down when a test grouping is clicked.
- Every git interaction checks for existence of local git repo and reclones if it does not exist. We should probably transition our app to use the headless client to directly update the remote repo, rather than having to deal with temporary clones.
- Repository url was not being saved due to a line of code in the controller being moved. The url is now saved properly.  We should restructure the way we're handling assignment validation and creation.
- The test controller had a minor bug, causing tests to sometimes be assigned to the wrong grouping.  This was fixed, but will eventually be removed once we implement drag-and-drop.


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Zero `rubocop` violations
- [x] My code receives an "A" when `rubycritic` is run
- [x] >90% test coverage of my changes
- [x] All new and existing tests passed