### PR TITLE
changes for the desired Assignments layout that Dr.Moore requested

### DIFF
--- a/app/assets/stylesheets/assignment_show.css
+++ b/app/assets/stylesheets/assignment_show.css
@@ -158,3 +158,9 @@
     padding: 0;
     margin: 0;
   }
+
+  /* Force left alignment for the entire Repository Name column */
+  #assignments-table th:first-child,
+  #assignments-table td:first-child {
+    text-align: left !important;
+  }

--- a/app/assets/stylesheets/assignment_show.css
+++ b/app/assets/stylesheets/assignment_show.css
@@ -159,8 +159,8 @@
     margin: 0;
   }
 
-  /* Force left alignment for the entire Repository Name column */
-  #assignments-table th:first-child,
-  #assignments-table td:first-child {
-    text-align: left !important;
-  }
+/* Specific rule to ensure left alignment on the columns */
+#assignments-table th.text-left,
+#assignments-table td.text-left {
+  text-align: left !important;
+}

--- a/app/views/assignments/index.html.erb
+++ b/app/views/assignments/index.html.erb
@@ -1,38 +1,40 @@
 <div class="assignments-wrapper">
 
-<h1>Assignments</h1>
+  <h1>Assignments</h1>
 
-<div class="flex justify-center">
-  <%= render partial: "search/form", locals: { results: [] } %>
-</div>
-  <div class="assignments-table-container">
-    <table id="assignments-table" class="assignments-table">
-      <thead>
-        <tr>
-          <th onclick="sortTable(0)">Repository Name <span id="arrow-0">&#x25B2;</span></th>
-          <th onclick="sortTable(1)">Created On <span id="arrow-1">&#x25B2;</span></th>
-          <th onclick="sortTable(2)">Last Updated <span id="arrow-2">&#x25B2;</span></th>
-          <th>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @assignments.each do |assignment| %>
-          <tr>
-            <td>
-              <%= link_to assignment.repository_name, assignment.github_repository_url, target: "_blank", class: "btn-link" %>
-            </td>
-            <td><%= assignment.created_at.strftime("%m-%d-%Y %H:%M") %></td>
-            <td><%= assignment.updated_at.strftime("%m-%d-%Y %H:%M") %></td>
-            <td>
-              <%= link_to 'Export', create_and_download_zip_assignment_path(assignment), class: "btn btn-success" %>
-              <%= link_to 'Edit', assignment_path(assignment), class: "btn btn-primary" %>
-              <%= link_to 'Manage Permissions', users_assignment_path(assignment), class: "btn btn-secondary" %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+  <div class="flex justify-center">
+    <%= render partial: "search/form", locals: { results: [] } %>
   </div>
+  
+  <div class="assignments-table-container">
+  <table id="assignments-table" class="assignments-table">
+    <thead>
+      <tr>
+        <th onclick="sortTable(0)">Repository Name <span id="arrow-0">&#x25B2;</span></th>
+        <th onclick="sortTable(1)">Created On <span id="arrow-1">&#x25B2;</span></th>
+        <th onclick="sortTable(2)">Last Updated <span id="arrow-2">&#x25B2;</span></th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @assignments.each do |assignment| %>
+        <tr>
+          <td>
+            <%= link_to assignment.repository_name, assignment_path(assignment), class: "btn-link" %>
+          </td>
+          <td><%= assignment.created_at.strftime("%m-%d-%Y %H:%M") %></td>
+          <td><%= assignment.updated_at.strftime("%m-%d-%Y %H:%M") %></td>
+          <td>
+            <%= link_to 'Export to GradeScope', create_and_download_zip_assignment_path(assignment), class: "btn btn-success" %>
+            <%= link_to 'Manage Access', users_assignment_path(assignment), class: "btn btn-secondary" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  </div>
+  
   <%= link_to 'Create Assignment', new_assignment_path, class: 'btn btn-primary create-assignment-btn' %>
 </div>
 
@@ -45,13 +47,15 @@
     switching = true;
     dir = sortDirections[n]; // Use stored sorting direction for the clicked column
 
-    // Clear all arrows
+    // Clear all arrows and remove highlight from all columns
     for (let j = 0; j < 3; j++) {
       document.getElementById(`arrow-${j}`).innerHTML = dir === "asc" ? "&#x25B2;" : "&#x25BC;";
+      Array.from(table.rows).forEach(row => row.cells[j].classList.remove("highlight-column"));
     }
 
-    // Set correct arrow for the clicked column
+    // Set correct arrow for the clicked column and highlight it
     document.getElementById(`arrow-${n}`).innerHTML = dir === "asc" ? "&#x25B2;" : "&#x25BC;";
+    Array.from(table.rows).forEach(row => row.cells[n].classList.add("highlight-column"));
 
     while (switching) {
       switching = false;
@@ -98,3 +102,15 @@
     sortDirections[n] = dir === "asc" ? "desc" : "asc";
   }
 </script>
+
+<style>
+  /* Highlight sorted column */
+  .highlight-column {
+    background-color: #f0f8ff; /* Light background for sorted column */
+  }
+  
+  /* Left align text */
+  .text-left {
+    text-align: left;
+  }
+</style>

--- a/app/views/assignments/index.html.erb
+++ b/app/views/assignments/index.html.erb
@@ -10,22 +10,22 @@
   <table id="assignments-table" class="assignments-table">
     <thead>
       <tr>
-        <th onclick="sortTable(0)">Repository Name <span id="arrow-0">&#x25B2;</span></th>
-        <th onclick="sortTable(1)">Created On <span id="arrow-1">&#x25B2;</span></th>
-        <th onclick="sortTable(2)">Last Updated <span id="arrow-2">&#x25B2;</span></th>
+        <th class="text-left" onclick="sortTable(0)">Assignment Name<span id="arrow-0">&#x25B2;</span></th>
+        <th class="text-left" onclick="sortTable(1)">Created On<span id="arrow-1">&#x25B2;</span></th>
+        <th class="text-left" onclick="sortTable(2)">Last Updated<span id="arrow-2">&#x25B2;</span></th>
         <th>Actions</th>
       </tr>
     </thead>
     <tbody>
       <% @assignments.each do |assignment| %>
         <tr>
-          <td>
+          <td class="text-left"> 
             <%= link_to assignment.repository_name, assignment_path(assignment), class: "btn-link" %>
           </td>
-          <td><%= assignment.created_at.strftime("%m-%d-%Y %H:%M") %></td>
-          <td><%= assignment.updated_at.strftime("%m-%d-%Y %H:%M") %></td>
+          <td class="text-left"><%= assignment.created_at.strftime("%m-%d-%Y %H:%M") %></td>
+          <td class="text-left"><%= assignment.updated_at.strftime("%m-%d-%Y %H:%M") %></td>
           <td>
-            <%= link_to 'Export to GradeScope', create_and_download_zip_assignment_path(assignment), class: "btn btn-success" %>
+            <%= link_to 'Export to Gradescope', create_and_download_zip_assignment_path(assignment), class: "btn btn-success" %>
             <%= link_to 'Manage Access', users_assignment_path(assignment), class: "btn btn-secondary" %>
           </td>
         </tr>
@@ -56,7 +56,7 @@
     // Set correct arrow for the clicked column and highlight it
     document.getElementById(`arrow-${n}`).innerHTML = dir === "asc" ? "&#x25B2;" : "&#x25BC;";
     Array.from(table.rows).forEach(row => row.cells[n].classList.add("highlight-column"));
-
+    
     while (switching) {
       switching = false;
       rows = table.rows;

--- a/features/assignments_sorting.feature
+++ b/features/assignments_sorting.feature
@@ -4,18 +4,18 @@ Feature: Update Assignments view
     Given the following assignments with creation time exist:
         | assignment_name | repository_name   | created_at                          | updated_at                          |
         | assignment1     | assignment-1-repo | 2024-10-03 18:56:13.176651000 +0000 | 2024-10-03 18:56:13.176651000 +0000 |
-        | assignment2     | assignment-2-repo | 2024-10-03 18:56:13.176651000 +0000 | 2024-10-03 18:56:13.176651000 +0000 |
-        | assignment3     | assignment-3-repo | 2024-10-03 18:56:13.176651000 +0000 | 2024-10-03 18:56:13.176651000 +0000 |
+        | assignment2     | assignment-2-repo | 2024-10-03 18:56:13.876651000 +0000 | 2024-10-03 18:56:13.196651000 +0000 |
+        | assignment3     | assignment-3-repo | 2024-10-03 18:56:13.976651000 +0000 | 2024-10-03 18:56:13.186651000 +0000 |
 
 
   Scenario: Display assignments in a table
     Given I am on the "Assignment" page
-    Then I should see a table displaying assignments with columns for "Repository Name", "Created On", "Last Updated", and "Actions"
+    Then I should see a table displaying assignments with columns for "Assignment Name", "Created On", "Last Updated", and "Actions"
 
   Scenario: Sort assignments by repo name
     Given I am on the "Assignment" page
     Then the assignments should be sorted by "repo name" in "ascending" order
-    When I click on the "Repository Name" column header 
+    When I click on the "Assignment Name" column header 
     Then the assignments should be sorted by "repo name" in "descending" order
 
   Scenario: Sort assignments by creation date

--- a/features/assignments_table_ui.feature
+++ b/features/assignments_table_ui.feature
@@ -1,0 +1,26 @@
+Feature: Update Assignments view based on Wireframe
+    Background:
+        Given the following assignments with creation time exist:
+            | assignment_name | repository_name   | created_at                          | updated_at                          |
+            | assignment1     | assignment-1-repo | 2024-10-03 18:56:13.176651000 +0000 | 2024-10-03 18:56:13.176651000 +0000 |
+            | assignment2     | assignment-2-repo | 2024-10-03 18:56:13.176651000 +0000 | 2024-10-03 18:56:13.176651000 +0000 |
+            | assignment3     | assignment-3-repo | 2024-10-03 18:56:13.176651000 +0000 | 2024-10-03 18:56:13.176651000 +0000 |
+
+    Scenario Outline: Assignments table content is left justified with proper buttons
+        Given I am on the "Assignment" page
+        Then I should see "Assignment Name" column left justified
+        Then I should see "Created On" column left justified
+        Then I should see "Last Updated" column left justified
+        And I should see "Export to Gradescope" button in each assignment row
+        And I should see "Manage Access" button in each assignment row
+        And I should not see "Edit" button in each assignment row
+    
+    Scenario Outline: The column used for sorting in the Assignments table should be highlighted.
+        Given I am on the "Assignment" page
+        When I click on the "Assignment Name" column header
+        Then I should see "Assignment Name" column highlighted
+    
+    
+    Scenario Outline: Assignment name link should redirect to edit assignment view 
+        When I click on "assignment1" link
+        Then I should be redirected to the "Assignment Management" page for "assignment1"

--- a/features/assignments_table_ui.feature
+++ b/features/assignments_table_ui.feature
@@ -14,13 +14,18 @@ Feature: Update Assignments view based on Wireframe
         And I should see "Export to Gradescope" button in each assignment row
         And I should see "Manage Access" button in each assignment row
         And I should not see "Edit" button in each assignment row
-    
+    @javascript
     Scenario Outline: The column used for sorting in the Assignments table should be highlighted.
         Given I am on the "Assignment" page
         When I click on the "Assignment Name" column header
         Then I should see "Assignment Name" column highlighted
+        When I click on the "Created On" column header
+        Then I should see "Created On" column highlighted
+        When I click on the "Last Updated" column header
+        Then I should see "Last Updated" column highlighted
     
     
     Scenario Outline: Assignment name link should redirect to edit assignment view 
-        When I click on "assignment1" link
-        Then I should be redirected to the "Assignment Management" page for "assignment1"
+        Given I am on the "Assignment" page
+        When I click on "assignment-1-repo" link
+        Then I should be redirected to the "Assignment" page for "assignment1"

--- a/features/change_assignment_user_permission.feature
+++ b/features/change_assignment_user_permission.feature
@@ -26,52 +26,52 @@ Feature: Manage assignment access for each user
     And I am on the "Manage Assignments" page for user permissions
 
   Scenario: Grant a single user read access to an assignment 
-    When I click on "Manage Permissions" for "assignment-1-repo"
+    When I click on "Manage Access" for "assignment-1-repo"
     And I "select" "read" for the user "alice"
     And I click "Save Changes"
     Then I should see that "alice" has "read" access to the remote "assignment-1-repo" repository
 
   Scenario: Grant a single user write access to an assignment 
-    When I click on "Manage Permissions" for "assignment-2-repo"
+    When I click on "Manage Access" for "assignment-2-repo"
     And I "select" "write" for the user "alice"
     And I click "Save Changes"
     Then I should see that "alice" has "read-write" access to the remote "assignment-2-repo" repository
 
   Scenario: Grant all users read access to an assignment 
-    When I click on "Manage Permissions" for "assignment-1-repo"
+    When I click on "Manage Access" for "assignment-1-repo"
     And I select "Select All" for the "read" permission
     And I click "Save Changes"
     Then I should see that "alice" has "read" access to the remote "assignment-1-repo" repository
     And I should see that "bob" has "read" access to the remote "assignment-1-repo" repository
 
   Scenario: Remove all users read access to an assignment
-    When I click on "Manage Permissions" for "assignment-1-repo"
+    When I click on "Manage Access" for "assignment-1-repo"
     And I select "Revoke All" for the "read" permission
     And I click "Save Changes"
     Then I should see that "alice" has "no-permission" access to the remote "assignment-1-repo" repository
     And I should see that "bob" has "no-permission" access to the remote "assignment-1-repo" repository
    
   Scenario: Remove a single user's read access to an assignment
-    When I click on "Manage Permissions" for "assignment-3-repo"
+    When I click on "Manage Access" for "assignment-3-repo"
     And I "deselect" "read" for the user "bob"
     And I click "Save Changes"
     Then I should see that "bob" has "no-permission" access to the remote "assignment-3-repo" repository
 
   Scenario: Remove a single user's write access to an assignment
-    When I click on "Manage Permissions" for "assignment-3-repo"
+    When I click on "Manage Access" for "assignment-3-repo"
     And I "deselect" "write" for the user "alice"
     And I click "Save Changes"
     Then I should see that "alice" has "read" access to the remote "assignment-3-repo" repository
 
   Scenario: Remove all user's write access to an assignment
-    When I click on "Manage Permissions" for "assignment-3-repo"
+    When I click on "Manage Access" for "assignment-3-repo"
     And I select "Revoke All" for the "write" permission
     And I click "Save Changes"
     Then I should see that "alice" has "read" access to the remote "assignment-3-repo" repository
     And I should see that "bob" has "read" access to the remote "assignment-3-repo" repository
 
   Scenario: Grant all users write access to an assignments
-    When I click on "Manage Permissions" for "assignment-1-repo"
+    When I click on "Manage Access" for "assignment-1-repo"
     And I select "Select All" for the "write" permission
     And I click "Save Changes"
     Then I should see that "alice" has "read-write" access to the remote "assignment-1-repo" repository

--- a/features/step_definitions/assignment_table_steps.rb
+++ b/features/step_definitions/assignment_table_steps.rb
@@ -1,9 +1,9 @@
 When('I click on {string} link') do |assignment_name|
     find('a', text: assignment_name).click
   end
-  
+
 Then('I should be redirected to the {string} page for {string}') do |page_name, assignment_name|
-    expect(page).to have_content("#{page_name} for #{assignment_name}")
+    expect(page).to have_content("#{page_name}: #{assignment_name}")
 end
 
 Then('I should see {string} button in each assignment row') do |button_text|
@@ -12,9 +12,9 @@ Then('I should see {string} button in each assignment row') do |button_text|
     end
 end
 
-  
-  
-  
+
+
+
 
 Then('I should see {string} column left justified') do |column_name|
     column = find('#assignments-table th', text: column_name)
@@ -25,10 +25,10 @@ Then('I should see {string} column highlighted') do |column_name|
     header = find('th', text: column_name)
     expect(header[:class]).to include('highlight-column') # Check directly on the element with a short wait
 end
-  
-  
-  
-  
+
+
+
+
 Then('I should not see {string} button in each assignment row') do |button_text|
     within('#assignments-table tbody') do
       all('tr').each do |row|

--- a/features/step_definitions/assignment_table_steps.rb
+++ b/features/step_definitions/assignment_table_steps.rb
@@ -1,0 +1,38 @@
+When('I click on {string} link') do |assignment_name|
+    find('a', text: assignment_name).click
+  end
+  
+Then('I should be redirected to the {string} page for {string}') do |page_name, assignment_name|
+    expect(page).to have_content("#{page_name} for #{assignment_name}")
+end
+
+Then('I should see {string} button in each assignment row') do |button_text|
+    within('#assignments-table tbody') do
+        expect(page).to have_css('tr a', text: button_text, count: all('tr').size)
+    end
+end
+
+  
+  
+  
+
+Then('I should see {string} column left justified') do |column_name|
+    column = find('#assignments-table th', text: column_name)
+    expect(column[:class]).to include('text-left')
+end
+
+Then('I should see {string} column highlighted') do |column_name|
+    header = find('th', text: column_name)
+    expect(header[:class]).to include('highlight-column') # Check directly on the element with a short wait
+end
+  
+  
+  
+  
+Then('I should not see {string} button in each assignment row') do |button_text|
+    within('#assignments-table tbody') do
+      all('tr').each do |row|
+        expect(row).not_to have_link(button_text)
+      end
+    end
+  end

--- a/features/step_definitions/assignments_sorting_steps.rb
+++ b/features/step_definitions/assignments_sorting_steps.rb
@@ -4,9 +4,9 @@ Given("the following assignments with creation time exist:") do |table|
     end
 end
 
-Then('I should see a table displaying assignments with columns for "Repository Name", "Created On", "Last Updated", and "Actions"') do
+Then('I should see a table displaying assignments with columns for "Assignment Name", "Created On", "Last Updated", and "Actions"') do
     within('table') do
-        expect(page).to have_css('th', text: 'Repository Name')
+        expect(page).to have_css('th', text: 'Assignment Name')
         expect(page).to have_css('th', text: 'Created On')
         expect(page).to have_css('th', text: 'Last Updated')
         expect(page).to have_css('th', text: 'Actions')

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -16,16 +16,19 @@ end
 
 
 require 'cucumber/rails'
-
 require 'rack_session_access/capybara'
-
 require 'webmock/cucumber'
 require 'capybara/rspec'
 require 'selenium-webdriver'
 
-Capybara.javascript_driver = :selenium_chrome
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new app, browser: :chrome,
+    options: Selenium::WebDriver::Chrome::Options.new(args: %w[headless disable-gpu])
+end
 
-WebMock.disable_net_connect!(allow_localhost: true)
+Capybara.javascript_driver = :chrome
+
+WebMock.disable_net_connect!(allow_localhost: true, allow: 'chromedriver.storage.googleapis.com')
 
 # By default, any exception happening in your Rails application will bubble up
 # to Cucumber so that your scenario will fail. This is a different from how
@@ -55,12 +58,12 @@ end
 # You may also want to configure DatabaseCleaner to use different strategies for certain features and scenarios.
 # See the DatabaseCleaner documentation for details. Example:
 #
-#   Before('@no-txn,@selenium,@culerity,@celerity,@javascript') do
-#     # { except: [:widgets] } may not do what you expect here
-#     # as Cucumber::Rails::Database.javascript_strategy overrides
-#     # this setting.
-#     DatabaseCleaner.strategy = :truncation
-#   end
+Before('@no-txn,@selenium,@culerity,@celerity,@javascript') do
+  # { except: [:widgets] } may not do what you expect here
+  # as Cucumber::Rails::Database.javascript_strategy overrides
+  # this setting.
+  DatabaseCleaner.strategy = :truncation
+end
 #
 #   Before('not @no-txn', 'not @selenium', 'not @culerity', 'not @celerity', 'not @javascript') do
 #     DatabaseCleaner.strategy = :transaction


### PR DESCRIPTION
<!--- Provide a concise title -->
Assignments Table UI Update
## Description
<!--- Describe your changes in detail -->
Left-justified text for repository name
Button renaming of Manager permissions
Highlighting sorted column
Retarget link to edit page
Remove “Edit” button
## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/a87b1eaa-94ab-4923-81ec-2c9ca529c2ef)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Zero `rubocop` violations
- [x] My code receives an "A" when `rubycritic` is run
- [x] >90% test coverage of my changes
- [x] All new and existing tests passed