### PR TITLE
Fix Chrome Driver Connection Issue

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -26,6 +26,7 @@ Capybara.register_driver :chrome do |app|
     options: Selenium::WebDriver::Chrome::Options.new(args: %w[headless disable-gpu])
 end
 
+Capybara.server = :puma
 Capybara.javascript_driver = :chrome
 
 WebMock.disable_net_connect!(allow_localhost: true, allow: 'chromedriver.storage.googleapis.com')


### PR DESCRIPTION
<!--- Provide a concise title -->

## Description
<!--- Describe your changes in detail -->
Some team members experienced issues with the headless Chrome Driver not connecting properly to the server when running Cucumber tests.  Configuring the server explicitly fixed this issue.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Test suite now runs on machines experiencing this issue.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Zero `rubocop` violations
- [ ] My code receives an "A" when `rubycritic` is run
- [x] >90% test coverage of my changes
- [x] All new and existing tests passed