### PR TITLE
Add `files_to_submit` column to `Assignments`

### DIFF
--- a/db/migrate/20241112200747_add_files_to_submit_to_assignments.rb
+++ b/db/migrate/20241112200747_add_files_to_submit_to_assignments.rb
@@ -1,0 +1,5 @@
+class AddFilesToSubmitToAssignments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :assignments, :files_to_submit, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_27_212147) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_12_200747) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -45,6 +45,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_27_212147) do
     t.string "repository_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "files_to_submit"
   end
 
   create_table "permissions", force: :cascade do |t|


### PR DESCRIPTION
<!--- Provide a concise title -->

## Description
<!--- Describe your changes in detail -->
Adds the `files_to_submit` column to `Assignments` to facilitate modification of the `files_to_submit` variable in the `run_autograder` script when a new assignment is created.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Test suite was run

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Zero `rubocop` violations
- [ ] My code receives an "A" when `rubycritic` is run
- [x] >90% test coverage of my changes
- [x] All new and existing tests passed