### PR TITLE
fix production migration

### DIFF
--- a/db/migrate/20241014224806_rename_number_to_position_in_tests_and_test_groupings_test.rb
+++ b/db/migrate/20241014224806_rename_number_to_position_in_tests_and_test_groupings_test.rb
@@ -1,6 +1,6 @@
 class RenameNumberToPositionInTestsAndTestGroupingsTest < ActiveRecord::Migration[7.2]
   def change
-    change_column :tests, :position, :integer
-    change_column :test_groupings, :position, :integer
+    change_column :tests, :position, :integer,  using: 'position::integer'
+    change_column :test_groupings, :position, :integer,  using: 'position::integer'
   end
 end

--- a/db/migrate/20241014224806_rename_number_to_position_in_tests_and_test_groupings_test.rb
+++ b/db/migrate/20241014224806_rename_number_to_position_in_tests_and_test_groupings_test.rb
@@ -1,6 +1,11 @@
 class RenameNumberToPositionInTestsAndTestGroupingsTest < ActiveRecord::Migration[7.2]
   def change
-    change_column :tests, :position, :integer, using: 'position::integer'
-    change_column :test_groupings, :position, :integer, using: 'position::integer'
+    if ActiveRecord::Base.connection.adapter_name.downcase == 'sqlite'
+      change_column :tests, :position, :integer
+      change_column :test_groupings, :position, :integer
+    else
+      change_column :tests, :position, :integer, using: 'position::integer'
+      change_column :test_groupings, :position, :integer, using: 'position::integer'
+    end
   end
 end

--- a/db/migrate/20241014224806_rename_number_to_position_in_tests_and_test_groupings_test.rb
+++ b/db/migrate/20241014224806_rename_number_to_position_in_tests_and_test_groupings_test.rb
@@ -1,6 +1,6 @@
 class RenameNumberToPositionInTestsAndTestGroupingsTest < ActiveRecord::Migration[7.2]
   def change
-    change_column :tests, :position, :integer,  using: 'position::integer'
-    change_column :test_groupings, :position, :integer,  using: 'position::integer'
+    change_column :tests, :position, :integer, using: 'position::integer'
+    change_column :test_groupings, :position, :integer, using: 'position::integer'
   end
 end

--- a/db/migrate/20241027212147_rename_and_change_actual_test_in_tests.rb
+++ b/db/migrate/20241027212147_rename_and_change_actual_test_in_tests.rb
@@ -1,6 +1,6 @@
 class RenameAndChangeActualTestInTests < ActiveRecord::Migration[7.2]
   def change
     rename_column :tests, :actual_test, :test_block
-    change_column :tests, :test_block, :jsonb, default: {}
+    change_column :tests, :test_block, :jsonb, using: 'test_block::jsonb', default: {}
   end
 end

--- a/db/migrate/20241027212147_rename_and_change_actual_test_in_tests.rb
+++ b/db/migrate/20241027212147_rename_and_change_actual_test_in_tests.rb
@@ -1,6 +1,10 @@
 class RenameAndChangeActualTestInTests < ActiveRecord::Migration[7.2]
   def change
     rename_column :tests, :actual_test, :test_block
-    change_column :tests, :test_block, :jsonb, using: 'test_block::jsonb', default: {}
+    if ActiveRecord::Base.connection.adapter_name.downcase == 'sqlite'
+      change_column :tests, :test_block, :jsonb, default: {}
+    else
+      change_column :tests, :test_block, :jsonb, using: 'test_block::jsonb', default: {}
+    end
   end
 end

--- a/db/migrate/20241113201410_change_files_to_submit_to_assignments.rb
+++ b/db/migrate/20241113201410_change_files_to_submit_to_assignments.rb
@@ -1,5 +1,9 @@
 class ChangeFilesToSubmitToAssignments < ActiveRecord::Migration[7.2]
   def change
-    change_column :assignments, :files_to_submit, :jsonb, using: 'files_to_submit::jsonb', default: { "files_to_submit": [] }
+    if ActiveRecord::Base.connection.adapter_name.downcase == 'sqlite'
+      change_column :assignments, :files_to_submit, :jsonb, default: { "files_to_submit": [] }
+    else
+      change_column :assignments, :files_to_submit, :jsonb, using: 'files_to_submit::jsonb', default: { "files_to_submit": [] }
+    end
   end
 end

--- a/db/migrate/20241113201410_change_files_to_submit_to_assignments.rb
+++ b/db/migrate/20241113201410_change_files_to_submit_to_assignments.rb
@@ -1,5 +1,5 @@
 class ChangeFilesToSubmitToAssignments < ActiveRecord::Migration[7.2]
   def change
-    change_column :assignments, :files_to_submit, :jsonb, default: { "files_to_submit": [] }
+    change_column :assignments, :files_to_submit, :jsonb, using: 'files_to_submit::jsonb', default: { "files_to_submit": [] }
   end
 end


### PR DESCRIPTION
Changed migrations to fix db:migrate on production

## Description
<!--- Describe your changes in detail -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Zero `rubocop` violations
- [x] My code receives an "A" when `rubycritic` is run
- [x] >90% test coverage of my changes
- [x] All new and existing tests passed