### PR TITLE
Deploy Key Big Fix

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -68,6 +68,7 @@ class Assignment < ActiveRecord::Base
   def assignment_repo_init(github_token, user)
     create_repo_from_template(github_token)
     clone_repo_to_local(github_token)
+    # Create and add deploy key for the assignment repository
     create_and_add_deploy_key(
       github_token,
       self.repository_name,
@@ -75,12 +76,12 @@ class Assignment < ActiveRecord::Base
       self.local_repository_path,
       false
     )
-    # TODO: This should add the key to the auto-grader core repo
+    # Create and add deploy key for autograder core
     create_and_add_deploy_key(
       github_token,
-      self.repository_name,
+      ENV["GITHUB_AUTOGRADER_CORE_REPO"],
       ENV["GITHUB_COURSE_ORGANIZATION"],
-      self.local_repository_path,
+      ENV["ASSIGNMENTS_BASE_PATH"],
       true
     )
     init_run_autograder_script(user, github_token)

--- a/config/local_env.yml
+++ b/config/local_env.yml
@@ -1,3 +1,4 @@
 GITHUB_TEMPLATE_REPO_URL: 'philipritchey/autograded-assignment-template'
+GITHUB_AUTOGRADER_CORE_REPO: 'autograder-core'
 GITHUB_COURSE_ORGANIZATION: 'AutograderFrontend'
 ASSIGNMENTS_BASE_PATH: 'assignment-repos/'


### PR DESCRIPTION
<!--- Provide a concise title -->

## Description
<!--- Describe your changes in detail -->
This PR solves the issue in which two deploy keys were being generated and added to the assignment repository.  Instead, one of the two is now added to the organization's `autograder-core` repository.  The new environment variable has already been added to our Heroku deployment.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Updated tests that were previously passing erroneously and ran full test suite.

## Screenshots (if appropriate):
Assignment Repository Deploy Keys:
![image](https://github.com/user-attachments/assets/a86857f3-804a-4a24-b33b-36abfd840b10)

Autograder Core Deploy Keys:
![image](https://github.com/user-attachments/assets/60640ec9-1f6e-4d94-a2ba-fa51d912496c)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Zero `rubocop` violations
- [ ] My code receives an "A" when `rubycritic` is run
- [x] >90% test coverage of my changes
- [x] All new and existing tests passed