### PR TITLE
fix fileitem warning

### DIFF
--- a/features/step_definitions/assignment_table_steps.rb
+++ b/features/step_definitions/assignment_table_steps.rb
@@ -1,6 +1,5 @@
 When('I click on {string} link') do |repository_name|
   @assignment = Assignment.find_or_create_by!(repository_name: repository_name)
-  FileItem = Struct.new(:name, :path, :type, :children)
   stub_request(:get, "https://api.github.com/repos/AutograderFrontend/#{@assignment.repository_name}/contents/tests/c++")
   .with(
     headers: {

--- a/features/step_definitions/display_tests_steps.rb
+++ b/features/step_definitions/display_tests_steps.rb
@@ -5,7 +5,6 @@ end
 
   Given('I am on the "Assignment Management" page for {string}') do |assignment_name|
     @assignment = Assignment.find_or_create_by!(assignment_name: assignment_name)
-    FileItem = Struct.new(:name, :path, :type, :children)
     stub_request(:get, "https://api.github.com/repos/AutograderFrontend/#{@assignment.repository_name}/contents/tests/c++")
     .with(
       headers: {

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -93,3 +93,5 @@ def check_test_block(type)
     raise "Unknown test type: #{type}"
   end
 end
+
+FileItem = Struct.new(:name, :path, :type, :children)

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -623,8 +623,8 @@ RSpec.describe AssignmentsController, type: :controller do
   end
 
   describe 'POST #update_order' do
-  let!(:test1) { create(:test, assignment: assignment, position: 1, name: 'Test 1') }
-  let!(:test2) { create(:test, assignment: assignment, position: 2, name: 'Test 2') }
+  let!(:test1) { create(:test, assignment: assignment, position: 1, name: 'Test 1', test_block: { code: 'Test code' }, test_type: 'unit') }
+  let!(:test2) { create(:test, assignment: assignment, position: 2, name: 'Test 2', test_block: { code: 'Test code' }, test_type: 'unit') }
 
   before do
     allow_any_instance_of(AssignmentsController).to receive(:current_user_and_token).and_return([ user, 'mock_github_token' ])


### PR DESCRIPTION
Fixed the FileItem warning in cucumber steps

## Description
<!--- Describe your changes in detail -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Zero `rubocop` violations
- [ ] My code receives an "A" when `rubycritic` is run
- [ ] >90% test coverage of my changes
- [ ] All new and existing tests passed