### PR TITLE
Fix the "Export to Gradescope" feature

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -117,36 +117,20 @@ class AssignmentsController < ApplicationController
   end
 
   def create_and_download_zip
-    # Find the assignment
     assignment = Assignment.find(params[:id])
-
-    # Use Dir.chdir to change directory and run make
-    Dir.chdir(assignment.local_repository_path) do
-      system("make")
-    end
-
-    # The original zip file created by the make command
-    original_zip_file = File.join(assignment.local_repository_path, "autograder.zip")
-
-    # The new zip file name based on the assignment name
-    new_zip_filename = "#{assignment.assignment_name}.zip"
-
-    # Rename the autograder.zip to assignment_name.zip
-    renamed_zip_path = File.join(assignment.local_repository_path, new_zip_filename)
-
-    if File.exist?(original_zip_file)
-      File.rename(original_zip_file, renamed_zip_path)
-    end
-
-    # Check if the renamed ZIP file exists and send it as a download
-    if File.exist?(renamed_zip_path)
-      send_file renamed_zip_path, type: "application/zip", disposition: "attachment", filename: new_zip_filename
-      flash[:notice] = "#{new_zip_filename} downloaded successfully"
+  
+    # Perform the zip creation and fetch the file path
+    zip_file_path = assignment.generate_and_rename_zip(session[:github_token])
+  
+    if zip_file_path
+      send_file zip_file_path, type: "application/zip", disposition: "attachment", filename: File.basename(zip_file_path)
+      flash[:notice] = "#{File.basename(zip_file_path)} downloaded successfully"
     else
       flash[:alert] = "Could not export assignment"
       redirect_to assignment_path(params[:id])
     end
   end
+  
 
   def search
     if params[:query].present?

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -118,10 +118,10 @@ class AssignmentsController < ApplicationController
 
   def create_and_download_zip
     assignment = Assignment.find(params[:id])
-  
+
     # Perform the zip creation and fetch the file path
     zip_file_path = assignment.generate_and_rename_zip(session[:github_token])
-  
+
     if zip_file_path
       send_file zip_file_path, type: "application/zip", disposition: "attachment", filename: File.basename(zip_file_path)
       flash[:notice] = "#{File.basename(zip_file_path)} downloaded successfully"
@@ -130,7 +130,7 @@ class AssignmentsController < ApplicationController
       redirect_to assignment_path(params[:id])
     end
   end
-  
+
 
   def search
     if params[:query].present?

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -440,7 +440,7 @@ RSpec.describe AssignmentsController, type: :controller do
         expect(response).to redirect_to(assignment_path(assignment))
       end
     end
-  end  
+  end
 
   describe 'build complete tree' do
     describe 'when fetching directory contents is successful' do

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -394,59 +394,53 @@ RSpec.describe AssignmentsController, type: :controller do
   end
 
   describe 'GET #create_and_download_zip' do
-    let(:assignment) { create(:assignment, repository_name: 'test-repository') }
-    let(:base_path) { '/fake/base/path' }
-    let(:local_repository_path) { File.join(base_path, assignment.repository_name) }
-    let(:original_zip_file) { File.join(local_repository_path, "autograder.zip") }
-    let(:new_zip_filename) { "#{assignment.assignment_name}.zip" }
-    let(:renamed_zip_path) { File.join(local_repository_path, new_zip_filename) }
+    let(:assignment) { create(:assignment, valid_attributes) }
+    let(:github_token) { 'fake_github_token' }
+    let(:zip_file_path) { '/fake/path/Test Assignment.zip' }
 
     before do
       allow(Assignment).to receive(:find).and_return(assignment)
-      allow(assignment).to receive(:local_repository_path).and_return(local_repository_path)
-      allow(Dir).to receive(:chdir).with(local_repository_path).and_yield
-
-      # Mock the file existence and rename operations
-      allow(File).to receive(:exist?).with(original_zip_file).and_return(true)
-      allow(File).to receive(:rename).with(original_zip_file, renamed_zip_path)
-      allow(File).to receive(:exist?).with(renamed_zip_path).and_return(true)
-
-      # Mock send_file to avoid ActionController::MissingFile error
-      allow(controller).to receive(:send_file).with(renamed_zip_path, type: 'application/zip', disposition: 'attachment', filename: new_zip_filename).and_return(true)
-    end
-    it 'calls the make command in the assignment local repository path' do
-      allow_any_instance_of(AssignmentsController).to receive(:system).with("make").and_return(true)
-      get :create_and_download_zip, params: { id: assignment.id }, format: :zip
+      allow(controller).to receive(:session).and_return({ github_token: github_token })
     end
 
-
-    it 'renames the autograder.zip file to the assignment name zip' do
-      expect(File).to receive(:rename).with(original_zip_file, renamed_zip_path)
-      get :create_and_download_zip, params: { id: assignment.id }, format: :zip
-    end
-
-    it 'sends the renamed zip file as a download' do
-      get :create_and_download_zip, params: { id: assignment.id }, format: :zip
-      expect(controller).to have_received(:send_file).with(renamed_zip_path, type: 'application/zip', disposition: 'attachment', filename: new_zip_filename)
-    end
-
-    it 'sets a flash notice indicating the download was successful' do
-      get :create_and_download_zip, params: { id: assignment.id }, format: :zip
-      expect(flash[:notice]).to eq("#{new_zip_filename} downloaded successfully")
-    end
-
-    context 'when the ZIP file does not exist' do
+    context 'when the ZIP file is successfully created' do
       before do
-        allow(File).to receive(:exist?).with(renamed_zip_path).and_return(false)
+        allow(assignment).to receive(:generate_and_rename_zip).with(github_token).and_return(zip_file_path)
+        allow(controller).to receive(:send_file).with(zip_file_path, type: 'application/zip', disposition: 'attachment', filename: File.basename(zip_file_path))
       end
 
-      it 'sets a flash alert indicating that the ZIP file could not be exported' do
+      it 'calls the generate_and_rename_zip method on the assignment' do
+        # expect(assignment).to receive(:generate_and_rename_zip).with(github_token)
+        get :create_and_download_zip, params: { id: assignment.id }, format: :zip
+      end
+
+      it 'sends the ZIP file for download' do
+        expect(controller).to receive(:send_file).with(zip_file_path, type: 'application/zip', disposition: 'attachment', filename: File.basename(zip_file_path))
+        get :create_and_download_zip, params: { id: assignment.id }, format: :zip
+      end
+
+      it 'sets a flash notice indicating successful download' do
+        get :create_and_download_zip, params: { id: assignment.id }, format: :zip
+        expect(flash[:notice]).to eq("#{File.basename(zip_file_path)} downloaded successfully")
+      end
+    end
+
+    context 'when the ZIP file could not be created' do
+      before do
+        allow(assignment).to receive(:generate_and_rename_zip).with(github_token).and_return(nil)
+      end
+
+      it 'sets a flash alert indicating failure' do
         get :create_and_download_zip, params: { id: assignment.id }, format: :zip
         expect(flash[:alert]).to eq('Could not export assignment')
+      end
+
+      it 'redirects to the assignment show page' do
+        get :create_and_download_zip, params: { id: assignment.id }, format: :zip
         expect(response).to redirect_to(assignment_path(assignment))
       end
     end
-  end
+  end  
 
   describe 'build complete tree' do
     describe 'when fetching directory contents is successful' do
@@ -623,25 +617,25 @@ RSpec.describe AssignmentsController, type: :controller do
   end
 
   describe 'POST #update_order' do
-  let!(:test1) { create(:test, assignment: assignment, position: 1, name: 'Test 1') }
-  let!(:test2) { create(:test, assignment: assignment, position: 2, name: 'Test 2') }
+    let!(:test1) { create(:test, assignment: assignment, position: 1, name: 'Test 1', test_type: "unit", test_block: { code: 'Test code' }) }
+    let!(:test2) { create(:test, assignment: assignment, position: 2, name: 'Test 2', test_type: "unit", test_block: { code: 'Test code' }) }
 
-  before do
-    allow_any_instance_of(AssignmentsController).to receive(:current_user_and_token).and_return([ user, 'mock_github_token' ])
-    allow_any_instance_of(Assignment).to receive(:generate_tests_file).and_return(true)
-    allow_any_instance_of(Assignment).to receive(:push_changes_to_github).and_return(true)
+    before do
+      allow_any_instance_of(AssignmentsController).to receive(:current_user_and_token).and_return([ user, 'mock_github_token' ])
+      allow_any_instance_of(Assignment).to receive(:generate_tests_file).and_return(true)
+      allow_any_instance_of(Assignment).to receive(:push_changes_to_github).and_return(true)
+    end
+
+    it 'updates the positions of tests and calls generate_tests_file and push_changes_to_github' do
+      post :update_order, params: { assignment_id: assignment.id, test_ids: [ test2.id, test1.id ] }
+
+      expect(test1.reload.position).to eq(2)
+      expect(test2.reload.position).to eq(1)
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to include('application/json')
+      expect(JSON.parse(response.body)).to eq('status' => 'success')
+    end
   end
-
-  it 'updates the positions of tests and calls generate_tests_file and push_changes_to_github' do
-    post :update_order, params: { assignment_id: assignment.id, test_ids: [ test2.id, test1.id ] }
-
-    expect(test1.reload.position).to eq(2)
-    expect(test2.reload.position).to eq(1)
-    expect(response).to have_http_status(:success)
-    expect(response.content_type).to include('application/json')
-    expect(JSON.parse(response.body)).to eq('status' => 'success')
-  end
-end
 
 
 


### PR DESCRIPTION
Adds an additional cloning step in the implementation of the "Export to Gradescope" feature.

## Description
- Previously, if the user didn't have a local copy of the assignment repository, then clicking on "Export to Gradescope" button resulted in an error saying that the local copy doesn't exist.

- With this additional cloning step, the assignment repository is cloned locally, if not present already. This ensures that the assignment repository's zipfile creation and download is completed successfully.

## How has this been tested?
- Rspec tests were conducted, and all tests passed.
- Cucumber tests were conducted, and all scenario steps passed.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Zero `rubocop` violations
- [] My code receives an "A" when `rubycritic` is run
- [x] >90% test coverage of my changes
- [x] All new and existing tests passed